### PR TITLE
Relax ptrace/signal permissions

### DIFF
--- a/etc/apparmor.d/init-systemd
+++ b/etc/apparmor.d/init-systemd
@@ -44,30 +44,12 @@ profile init-systemd /lib/systemd/** flags=(attach_disconnected) {
   capability syslog,
 
   ## Allow us to send ourselves signals.
-  signal (receive, send) peer=init-systemd,
-  signal (receive, send) peer=init-systemd//null-/usr/sbin/jitterentropy-rngd,
-  signal (receive, send) peer=init-systemd//null-/lib/systemd/systemd-udevd,
-  signal (receive, send) peer=init-systemd//null-/sbin/auditd,
-  signal (receive, send) peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall,
-  signal (receive, send) peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall,
-  signal (receive, send) peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall//null-/usr/bin/whonix-gateway-firewall,
-  signal (receive, send) peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall//null-/usr/bin/whonix-gateway-firewall//null-/usr/sbin/xtables-nft-multi,
+  ## TODO: Restrict.
+  signal,
 
-  ## Allow us to kill any process,
-  signal set=(term, kill, stop, int),
-
-  ## Allow us to gain some information about ourselves, whonixcheck
-  ## and unconfined processes.
-  ptrace read peer=init-systemd,
-  ptrace read peer=init-systemd//null-/usr/sbin/jitterentropy-rngd,
-  ptrace read peer=init-systemd//null-/lib/systemd/systemd-udevd,
-  ptrace read peer=init-systemd//null-/sbin/auditd,
-  ptrace read peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall,
-  ptrace read peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall,
-  ptrace read peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall//null-/usr/bin/whonix-gateway-firewall,
-  ptrace read peer=init-systemd//null-/usr/lib/whonix-firewall/enable-firewall//null-/usr/bin/whonix_firewall//null-/usr/bin/whonix-gateway-firewall//null-/usr/sbin/xtables-nft-multi,
-  ptrace read peer=/usr/bin/whonixcheck,
-  ptrace read peer=unconfined,
+  ## Allow us to ptrace processes.
+  ## TODO: Restrict.
+  ptrace (read, readby, tracedby),
 
   ## TODO: Restrict if possible.
   unix,


### PR DESCRIPTION
The restrictions from https://github.com/Whonix/apparmor-profile-everything/pull/2 break many things due to https://forums.whonix.org/t/apparmor-for-complete-system-including-init-pid1-systemd-everything-full-system-mac-policy/8339/74