### PR TITLE
Fixes

### DIFF
--- a/etc/apparmor.d/apt-get
+++ b/etc/apparmor.d/apt-get
@@ -4,7 +4,6 @@
 #include <tunables/global>
 
 profile /usr/bin/rapt flags=(attach_disconnected) {
-  #include <abstractions/base>
   ##include <abstractions/dangerous-files>
 
   ## TODO: Further restict these. Use extended capability rules.
@@ -97,6 +96,7 @@ profile /usr/bin/rapt flags=(attach_disconnected) {
 
   ## Procfs access.
   /proc/ r,
+  /proc/filesystems r,
   /proc/*/fd/ r,
   /proc/*/{,stat,comm,cmdline} r,
   /proc/*/task/ r,

--- a/etc/apparmor.d/apt-get
+++ b/etc/apparmor.d/apt-get
@@ -3,7 +3,7 @@
 
 #include <tunables/global>
 
-profile /usr/bin/apt-get flags=(attach_disconnected) {
+profile /usr/bin/rapt flags=(attach_disconnected) {
   #include <abstractions/base>
   ##include <abstractions/dangerous-files>
 

--- a/etc/apparmor.d/init-systemd
+++ b/etc/apparmor.d/init-systemd
@@ -181,6 +181,9 @@ profile init-systemd /lib/systemd/** flags=(attach_disconnected) {
   /proc/*/net/dev r,
   /proc/{,stat,cpuinfo,filesystems,meminfo,swaps,cmdline,uptime} r,
   /proc/sys/** r,
+  /proc/asound/card[0-9]*/ r,
+  /proc/asound/card[0-9]*/pcm[0-9]*/ r,
+  /proc/asound/card[0-9]*/pcm[0-9]*/sub[0-9]*/status r,
   owner /proc/sys/** rw,
   owner /proc/mtrr rw,
   owner /proc/*/{,setgroups,gid_map,uid_map} w,
@@ -276,8 +279,9 @@ profile init-systemd /lib/systemd/** flags=(attach_disconnected) {
 
   ## /var and /run access.
   /var/ r,
-  /var/{,cache,lib,log}/ r,
+  /var/{,cache,lib,log,spool}/ r,
   /var/cache/** r,
+  /var/cache/man/*/*[0-9]/ rw,
   /var/{,lib,log}/** rw,
   /var/lib/dpkg/info/** rpix,
   owner /var/{,cache,lib,db}/** rwkl,
@@ -288,5 +292,7 @@ profile init-systemd /lib/systemd/** flags=(attach_disconnected) {
   /{,var/}run/shm/** rwl,
   owner /{,var/}run/** rwk,
   owner /var/swapfile rw,
+  owner /var/backups/apt.extended_states w,
 
+  /srv/ r,
 }

--- a/usr/bin/rapt
+++ b/usr/bin/rapt
@@ -98,6 +98,11 @@ do
          shift
          continue
          ;;
+      --fix-broken)
+         command+="$1 "
+         shift
+         continue
+         ;;
       --no-install-recommends)
          command+="$1 "
          shift


### PR DESCRIPTION
rapt:
* Allows rapt to use --fix-broken
* Make the apt-get profile confine rapt instead
* Removed the base abstraction

init-systemd:
* Gives access to sound cards for pulseaudio
* Gives access to /var/spool/
* rw access to /var/cache/man/*/*[0-9]/ is needed by systemd-tmpfiles
* /var/backups/apt.extended_states and /srv/ are needed by something