### PR TITLE
Give access to all vport devices

### DIFF
--- a/etc/apparmor.d/abstractions/init-systemd
+++ b/etc/apparmor.d/abstractions/init-systemd
@@ -266,7 +266,7 @@
   owner /dev/mapper/control rw,
   owner /dev/dm-0 rw,
   owner /dev/mapper/swapfile w,
-  owner /dev/vport2p1 rw,
+  owner /dev/vport[0-9]* rw,
 
   ## Removable media.
   owner /media/ r,


### PR DESCRIPTION
Otherwise, the cursor can be messed up when using KVM.