### PR TITLE
Remove CAP_SYS_TIME capability

### DIFF
--- a/etc/apparmor.d/abstractions/init-systemd
+++ b/etc/apparmor.d/abstractions/init-systemd
@@ -4,7 +4,6 @@
   #include <abstractions/gnome>
 
   ## TODO: Further restict these. Use extended capability rules.
-  ## TODO: Create sdwdate AppArmor profile and remove sys_time.
   ## TODO: Create whonix-firewall profile and remove net_admin.
   ## TODO: Create auditd(/journald?) profile and remove audit_*.
   ## TODO: Create journald profile and remove syslog.
@@ -31,7 +30,6 @@
   capability sys_nice,
   capability sys_ptrace,
   capability sys_resource,
-  capability sys_time,
   capability sys_tty_config,
   capability syslog,
 


### PR DESCRIPTION
I created an sdwdate profile so this isn't needed in the main profile: https://github.com/Whonix/sdwdate/pull/22