### PR TITLE
Deny access to init.d

### DIFF
--- a/etc/apparmor.d/abstractions/dangerous-files
+++ b/etc/apparmor.d/abstractions/dangerous-files
@@ -104,3 +104,5 @@
   ## Prevent any changes to systemd.
   audit deny /**/systemd/ w,
   audit deny /**/systemd/** w,
+  audit deny /**/init.d/ w,
+  audit deny /**/init.d/** w,


### PR DESCRIPTION
Since we're denying access to all systemd folders, it makes sense to also deny access to init.d