### PR TITLE
Create systemd-shutdown profile and remove CAP_SYS_BOOT

### DIFF
--- a/etc/apparmor.d/abstractions/init-systemd
+++ b/etc/apparmor.d/abstractions/init-systemd
@@ -23,7 +23,6 @@
   capability setpcap,
   capability setuid,
   capability sys_admin,
-  capability sys_boot,
   capability sys_chroot,
   capability sys_nice,
   capability sys_ptrace,

--- a/etc/apparmor.d/systemd-shutdown
+++ b/etc/apparmor.d/systemd-shutdown
@@ -1,0 +1,28 @@
+## Copyright (C) 2012 - 2019 ENCRYPTED SUPPORT LP <adrelanos@riseup.net>
+## See the file COPYING for copying conditions.
+
+#include <tunables/global>
+
+profile systemd-shutdown /lib/systemd/systemd-shutdown flags=(attach_disconnected) {
+  #include <abstractions/base>
+
+  capability kill,
+  capability sys_boot,
+  capability sys_resource,
+
+  ptrace read,
+
+  signal send set=cont,
+  signal send set=stop,
+  signal send set=term,
+
+  /lib/systemd/systemd-shutdown mr,
+
+  /proc/ r,
+  /proc/cmdline r,
+  /proc/sys/kernel/core_pattern w,
+  /proc/*/{,cgroup,stat,cmdline} r,
+  /proc/*/fd/ r,
+
+  /dev/kmsg w,
+}

--- a/etc/apparmor.d/systemd-shutdown
+++ b/etc/apparmor.d/systemd-shutdown
@@ -23,6 +23,9 @@ profile systemd-shutdown /lib/systemd/systemd-shutdown flags=(attach_disconnecte
   /proc/sys/kernel/core_pattern w,
   /proc/*/{,cgroup,stat,cmdline} r,
   /proc/*/fd/ r,
+  owner /proc/*/environ r,
+  owner /proc/*/sched r,
 
   /dev/kmsg w,
+  /dev/pts/[0-9]* rw,
 }

--- a/etc/apparmor.d/systemd-shutdown
+++ b/etc/apparmor.d/systemd-shutdown
@@ -23,8 +23,7 @@ profile systemd-shutdown /lib/systemd/systemd-shutdown flags=(attach_disconnecte
   /proc/sys/kernel/core_pattern w,
   /proc/*/{,cgroup,stat,cmdline} r,
   /proc/*/fd/ r,
-  owner /proc/*/environ r,
-  owner /proc/*/sched r,
+  owner /proc/*/{,environ,sched} r,
 
   /dev/kmsg w,
   /dev/pts/[0-9]* rw,

--- a/etc/initramfs-tools/scripts/init-bottom/apparmor-profile-everything
+++ b/etc/initramfs-tools/scripts/init-bottom/apparmor-profile-everything
@@ -22,6 +22,7 @@ fi
 
 mount -t securityfs nosuid,nodev,noexec /sys/kernel/security
 
+echo "profile systemd-shutdown /lib/systemd/systemd-shutdown {}" | /sbin/apparmor_parser -a
 echo "profile systemd-modules-load /lib/systemd/systemd-modules-load {}" | /sbin/apparmor_parser -a
 echo "profile systemd-sysctl /lib/systemd/systemd-sysctl {}" | /sbin/apparmor_parser -a
 


### PR DESCRIPTION
https://forums.whonix.org/t/apparmor-for-complete-system-including-init-pid1-systemd-everything-full-system-mac-policy/8339/341