### PR TITLE
Put remove-system.map permissions in its own profile

### DIFF
--- a/etc/apparmor.d/abstractions/kicksecure-shell-script
+++ b/etc/apparmor.d/abstractions/kicksecure-shell-script
@@ -36,19 +36,6 @@
   /home/** rw,
   /etc/skel/ r,
   /etc/skel/** rw,
-
-  ## remove-system.map
-  owner / r,
-  owner /System.map* rw,
-  owner /boot/ r,
-  owner /boot/System.map* rw,
-  owner /usr/src/ r,
-  owner /usr/src/*/ r,
-  owner /usr/src/*/System.map* rw,
-  owner /lib/modules/ r,
-  owner /lib/modules/*/ r,
-  owner /lib/modules/*/*/ r,
-  owner /lib/modules/*/*/System.map* rw,
   
   ## panic-on-oops
   /proc/sys/kernel/panic_on_oops w,

--- a/etc/apparmor.d/kicksecure-shell-script
+++ b/etc/apparmor.d/kicksecure-shell-script
@@ -23,6 +23,18 @@
 
 /usr/lib/security-misc/remove-system.map flags=(attach_disconnected) {
   #include <abstractions/kicksecure-shell-script>
+  
+  owner / r,
+  owner /System.map* rw,
+  owner /boot/ r,
+  owner /boot/System.map* rw,
+  owner /usr/src/ r,
+  owner /usr/src/*/ r,
+  owner /usr/src/*/System.map* rw,
+  owner /lib/modules/ r,
+  owner /lib/modules/*/ r,
+  owner /lib/modules/*/*/ r,
+  owner /lib/modules/*/*/System.map* rw,
 }
 
 /usr/lib/security-misc/panic-on-oops flags=(attach_disconnected) {


### PR DESCRIPTION
Since these are such dangerous permissions (read access to kernel symbols), this makes it so only remove-system.map has those permissions and not any other of our shell scripts.