### PR TITLE
Deny write access to hard drives

### DIFF
--- a/etc/apparmor.d/abstractions/dangerous-files
+++ b/etc/apparmor.d/abstractions/dangerous-files
@@ -132,3 +132,7 @@
   audit deny /var/lib/hardened-kernel/** rw,
   audit deny /usr/share/hardened-kernel/ rw,
   audit deny /usr/share/hardened-kernel/** rw,
+
+  ## Deny write access to hard drives. Otherwise, an attacker can write to
+  ## e.g. /dev/sda to bypass restrictions.
+  audit deny /dev/sd* rw,

--- a/etc/apparmor.d/abstractions/init-systemd
+++ b/etc/apparmor.d/abstractions/init-systemd
@@ -228,7 +228,7 @@
   /dev/kvm rw,
   owner /dev/sr0 rwk,
   /dev/log rw,
-  owner /dev/sd* rwmk,
+  owner /dev/sd* r,
   owner /dev/kmsg rw,
   owner /dev/fb0 rw,
   owner /dev/vga_arbiter rw,


### PR DESCRIPTION
Otherwise, an attacker can write to e.g. /dev/sda to bypass restrictions.

Other devices might also be able to be abused in similar ways. We should comb through all /dev permissions and make sure they can't be abused.

We might also want to remove read access to /dev/sd* in case an attacker can abuse it to e.g. read the kernel image on disk.