### PR TITLE
Remove write access to /proc/mtrr

### DIFF
--- a/etc/apparmor.d/abstractions/init-systemd
+++ b/etc/apparmor.d/abstractions/init-systemd
@@ -174,9 +174,8 @@
   /proc/asound/card[0-9]*/ r,
   /proc/asound/card[0-9]*/pcm[0-9]*/ r,
   /proc/asound/card[0-9]*/pcm[0-9]*/sub[0-9]*/status r,
-  owner /proc/mtrr rw,
   owner /proc/*/{,setgroups,gid_map,uid_map} w,
-  owner /proc/{,kmsg,devices,modules} r,
+  owner /proc/{,kmsg,devices,modules,mtrr} r,
   owner /proc/tty/drivers r,
   owner /proc/sysvipc/{,shm,sem,msg} r,
 


### PR DESCRIPTION
This was only needed for Xorg which now has its own profile.