### PR TITLE
Add shred to kicksecure-shell-script abstraction

### DIFF
--- a/etc/apparmor.d/abstractions/kicksecure-shell-script
+++ b/etc/apparmor.d/abstractions/kicksecure-shell-script
@@ -31,6 +31,7 @@
   /{,usr/}bin/cp mrix,
   /{,usr/}bin/chown mrix,
   /{,usr/}bin/mktemp mrix,
+  /{,usr/}bin/shred mrix,
 
   ## permission-lockdown and first-boot-skel
   /home/** rw,


### PR DESCRIPTION
Whonix/security-misc#62 introduced shred instead of rm, so we need to allow it. Without it kernel upgrades is broken.