### PR TITLE
Improve `usr.bin.dbus-daemon`

### DIFF
--- a/etc/apparmor.d/usr.bin.dbus-daemon
+++ b/etc/apparmor.d/usr.bin.dbus-daemon
@@ -20,6 +20,7 @@ profile dbus-daemon /{,usr/}bin/dbus-daemon flags=(attach_disconnected) {
   /etc/passwd r,
   /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/*.xml r,
   /etc/xdg/tumbler/tumbler.rc r,
+  /etc/dbus-1/** r,
 
   /{,usr/}bin/dbus-daemon mr,
   /usr/lib/mate-notification-daemon/mate-notification-daemon mrix,
@@ -30,7 +31,7 @@ profile dbus-daemon /{,usr/}bin/dbus-daemon flags=(attach_disconnected) {
   /usr/lib/dconf/dconf-service mrix,
   /usr/bin/gnome-keyring-daemon mrix,
 
-  /{@{system_share_dirs},etc}/dbus-1/** r,
+  @{system_share_dirs}/dbus-1/** r,
   @{system_share_dirs}/glib-2.0/schemas/gschemas.compiled r,
   @{system_share_dirs}/defaults/at-spi2/accessibility.conf r,
   @{system_share_dirs}/desktop-base/profiles/xdg-config/xfce4/xfconf/xfce-perchannel-xml/*.xml{,.new} r,


### PR DESCRIPTION
Fix error `Failed to open "/usr/share/dbus-1/system.conf": Permission denied`